### PR TITLE
Subtract one (1) hour from the starting Late Night Animoon time

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Jeffrey is hereby banned from any and all Anime consumption, unless otherwise st
 	* roosterteeth.com
 ## II.A Late Night Animoon Exception
 Jeffrey is *generally* permitted to view anime during the hours of an active Late Night Animoon session.
-These hours are formally defined as Fridays from 11:00 PM to 4:00 AM. They are, however, subject to change based on unique cases
+These hours are formally defined as Fridays from 10:00 PM to 4:00 AM. They are, however, subject to change based on unique cases
 agreed upon by the owner (Joshua Ehling). Changes can involve extending either time constraint a maximum of 3 hours. 
 ## II.B Approved Anime Exception
 Jeffrey is only permitted to view anime outside of Late Night Animoon that has been specifically approved by the owner (Joshua Ehling) as well as co-officer Elijah Bendinsky.


### PR DESCRIPTION
I did the math. By subtracting an hour from the starting Late Night Animoon time, it would change from 11:00 PM to 10:00 PM, which coincides with the starting time shown on the official CSH calendar.